### PR TITLE
updated public image url to reflect new changes by supabase

### DIFF
--- a/pages/api/image-upload.js
+++ b/pages/api/image-upload.js
@@ -45,10 +45,12 @@ export default async function handler(req, res) {
       }
 
       // Construct public URL
+      // data.path returns the file name of the uploaded image
+      // supabase_basket also added to the link
       const url = `${process.env.SUPABASE_URL.replace(
         '.co',
         '.in'
-      )}/storage/v1/object/public/${data.Key}`;
+      )}/storage/v1/object/public/supavacation/${data.path}`;
 
       return res.status(200).json({ url });
     } catch (e) {


### PR DESCRIPTION
-- {data.key} returns undefined on the constructed public URL. 
-- supabase_basket has also been added to the public URL this case it is "supavacation"
-- {data.path} returns the file name of the newly uploaded image
![data](https://user-images.githubusercontent.com/38397394/205294325-ff4c74d4-8c1a-485c-ab1c-cf9635b0bc5a.png)
![data2](https://user-images.githubusercontent.com/38397394/205294330-ececf0e0-29b5-42a7-b5ac-414cb2b2f11a.png)
